### PR TITLE
chore: add engines field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
   "bugs": {
     "url": "https://github.com/NextCommunity/NextCommunity.github.io/issues"
   },
-  "homepage": "https://github.com/NextCommunity/NextCommunity.github.io#readme"
+  "homepage": "https://github.com/NextCommunity/NextCommunity.github.io#readme",
+  "engines": {
+    "node": ">=20.0.0"
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `engines` field to `package.json` specifying `node >= 20.0.0`
- This enforces the minimum Node.js version requirement, preventing build issues for contributors using incompatible versions
- Aligns with the Node.js 24 used in the deploy workflow

Closes #367