### PR TITLE
Trim bio on index page before truncating

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -46,7 +46,7 @@ layout: false
 
           {% set bio = person.data.bio %}
           {% if bio %}
-          <p class="mt-4 text-[var(--text-muted)] text-sm italic line-clamp-3">"{{ bio | truncate(120) }}"</p>
+          <p class="mt-4 text-[var(--text-muted)] text-sm italic line-clamp-3">"{{ bio | trim | truncate(120) }}"</p>
           {% endif %}
         </div>
 


### PR DESCRIPTION
Minor whitespace removed from a short bio at the end as seen in these two images.  A little cleaner.

<img width="417" height="380" alt="Screenshot 2026-05-03 at 2 01 07 am" src="https://github.com/user-attachments/assets/0881e25a-e786-4ab7-bd1e-5b5445c17c01" />
<img width="441" height="512" alt="Screenshot 2026-05-03 at 2 01 25 am" src="https://github.com/user-attachments/assets/fdbf9528-6597-438c-8c4c-d06ff63b6285" />
