### PR TITLE
Fix #468

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -31,7 +31,7 @@ layout: false
             {% set country = person.data.country %}
             {% set location = person.data.location %}
             {% if location or country %}
-            <div class="flex flex-col items-end text-right gap-0.5 text-[10px] bg-[var(--bg-footer)] text-[var(--text-muted)] px-2 py-1 rounded font-bold uppercase border border-[var(--border-color)] min-w-28 max-w-40 shrink-0">
+            <div class="flex flex-col items-end text-right gap-0.5 text-[10px] bg-[var(--bg-footer)] text-[var(--text-muted)] px-2 py-1 rounded font-bold uppercase border border-[var(--border-color)] min-w-[7rem] max-w-[10rem] shrink-0">
               {% if location %}<span>{{ location }}</span>{% endif %}
               {% if country %}<span>{{ country }}</span>{% endif %}
             </div>

--- a/src/index.njk
+++ b/src/index.njk
@@ -31,7 +31,7 @@ layout: false
             {% set country = person.data.country %}
             {% set location = person.data.location %}
             {% if location or country %}
-            <div class="flex flex-col items-end text-right gap-0.5 text-[10px] bg-[var(--bg-footer)] text-[var(--text-muted)] px-2 py-1 rounded font-bold uppercase border border-[var(--border-color)] min-w-[7rem] max-w-[10rem] shrink-0">
+            <div class="flex flex-col items-end text-right gap-0.5 text-[10px] bg-[var(--bg-footer)] text-[var(--text-muted)] px-2 py-1 rounded font-bold uppercase border border-[var(--border-color)] min-w-28 max-w-40 shrink-0">
               {% if location %}<span>{{ location }}</span>{% endif %}
               {% if country %}<span>{{ country }}</span>{% endif %}
             </div>

--- a/src/index.njk
+++ b/src/index.njk
@@ -31,7 +31,7 @@ layout: false
             {% set country = person.data.country %}
             {% set location = person.data.location %}
             {% if location or country %}
-            <div class="flex flex-col items-end text-right gap-0.5 text-[10px] bg-[var(--bg-footer)] text-[var(--text-muted)] px-2 py-1 rounded font-bold uppercase border border-[var(--border-color)]">
+            <div class="flex flex-col items-end text-right gap-0.5 text-[10px] bg-[var(--bg-footer)] text-[var(--text-muted)] px-2 py-1 rounded font-bold uppercase border border-[var(--border-color)] min-w-[7rem] max-w-[10rem] shrink-0">
               {% if location %}<span>{{ location }}</span>{% endif %}
               {% if country %}<span>{{ country }}</span>{% endif %}
             </div>

--- a/src/users/saishwadnere.yaml
+++ b/src/users/saishwadnere.yaml
@@ -9,5 +9,6 @@ location: Nashik
 role: Student
 languages: Java JavaScript React HTML CSS
 bio: |
-  Student studying at Sandip Institute of Technology and Research Centre.
-  Interested in Backend and Cloud. Building real systems. Mastery in React and CSS.
+  Computer Engineering student at Sandip Institute of Technology and Research Centre, Nashik.
+  Focused on backend development and cloud technologies, with strong experience in React and CSS.
+  Passionate about building scalable, real-world systems and continuously improving through hands-on projects.

--- a/src/users/saishwadnere.yaml
+++ b/src/users/saishwadnere.yaml
@@ -1,0 +1,13 @@
+name: Saish Milind Wadnere
+github: SaishWadnere
+email: saishwadnere3@gmail.com
+instagram: https://www.instagram.com/saish_wadnere/
+twitter: https://x.com/saishwadnere
+linkedin: https://www.linkedin.com/in/saish-wadnere/
+country: India
+location: Nashik
+role: Student
+languages: Java JavaScript React HTML CSS
+bio: |
+  Student studying at Sandip Institute of Technology and Research Centre.
+  Interested in Backend and Cloud. Building real systems. Mastery in React and CSS.


### PR DESCRIPTION
## Changes
- Added `min-w-28`, `max-w-40`, and `shrink-0` to the location/country metadata container in `src/index.njk` to prevent it from collapsing when name or role text is long
- Added my profile to the developer directory
## Context
The removal of `shrink-0` in PR #466 caused the metadata badge to squeeze to its minimum width whenever the name or role text was long, leading to an awkward vertical stack of single words. This fix adds width constraints to maintain a balanced layout.