### PR TITLE
System override: add secret pulse button

### DIFF
--- a/src/_includes/system-override.njk
+++ b/src/_includes/system-override.njk
@@ -17,6 +17,9 @@
         <button onclick="triggerSecretUnlock('matrix')" class="override-btn py-1.5 bg-green-500/5 hover:bg-green-500/20 text-green-500 text-[8px] border border-green-500/20 rounded transition-all">
             MATRIX
         </button>
+        <button onclick="triggerSecretUnlock('pulse')" class="override-btn py-1.5 bg-orange-500/5 hover:bg-orange-500/20 text-orange-400 text-[8px] border border-orange-500/20 rounded transition-all">
+            PULSE
+        </button>
         <button onclick="triggerForceSurge()"
             class="relative overflow-hidden py-2 px-6 bg-blue-600/20 text-blue-300 border-2 border-blue-400 rounded-lg font-bold tracking-[0.2em] transition-all hover:bg-blue-500/40 hover:shadow-[0_0_30px_rgba(59,130,246,0.6)] animate-pulse uppercase">
             <span class="relative z-10">Force Surge</span>


### PR DESCRIPTION
**Changes:**
- Added a PULSE button to the System Override panel.
- Connected the button to the existing triggerSecretUnlock('pulse') functionality.

**Testing:**
- Verified the PULSE button appears in the System Override panel.
- Verified clicking the button triggers the pulse secret.

<img width="1883" height="905" alt="Screenshot 2026-06-11 175559" src="https://github.com/user-attachments/assets/c2ee62e1-5286-40ad-9529-8982720da8b7" />

