### PR TITLE
Style pulse and Force Surge buttons in system override panel

### DIFF
--- a/src/_includes/system-override.njk
+++ b/src/_includes/system-override.njk
@@ -17,6 +17,9 @@
         <button onclick="triggerSecretUnlock('matrix')" class="override-btn py-1.5 bg-green-500/5 hover:bg-green-500/20 text-green-500 text-[8px] border border-green-500/20 rounded transition-all">
             MATRIX
         </button>
+        <button onclick="triggerSecretUnlock('pulse')" class="override-btn py-1.5 bg-orange-500/5 hover:bg-orange-500/20 text-orange-400 text-[8px] border border-orange-500/20 rounded transition-all">
+            PULSE
+        </button>
         <button onclick="triggerForceSurge()"
             class="relative overflow-hidden py-2 px-6 bg-blue-600/20 text-blue-300 border-2 border-blue-400 rounded-lg font-bold tracking-[0.2em] transition-all hover:bg-blue-500/40 hover:shadow-[0_0_30px_rgba(59,130,246,0.6)] animate-pulse uppercase">
             <span class="relative z-10">Force Surge</span>

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -279,6 +279,12 @@ html body #dev-tools[data-lock="true"] {
 #dev-tools button[onclick*="badge_click"] {
   color: #bc13fe !important;
 }
+#dev-tools button[onclick*="pulse"] {
+  color: #fbbf24 !important;
+}
+#dev-tools button[onclick*="triggerForceSurge"] {
+  color: #60a5fa !important; 
+}
 
 /**
  * 5. SELF DESTRUCT & REPAIR
@@ -496,7 +502,7 @@ body[data-level="6"]::after {
 /* Added via JS when XP increases */
 .xp-pulse {
   transform: scale(1.3);
-  color: white !important;
+  color: #f59e0b !important;
 }
 #jump-lvl {
   font-family: "Courier New", monospace;


### PR DESCRIPTION
## Summary

This PR updates the styling of the Pulse and Force Surge buttons in the System Override panel.

### Changes
- Added orange styling for the Pulse button to match the pulse easter egg.
- Updated the Force Surge button styling for better visuals.

Closes #522